### PR TITLE
chore: Bump version to publish with keywords

### DIFF
--- a/packages/directory-exists/package.json
+++ b/packages/directory-exists/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assertions/directory-exists",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/index.js",
   "files": [
     "dist/**/*"

--- a/packages/is-equal/package.json
+++ b/packages/is-equal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assertions/is-equal",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/index.js",
   "files": [
     "dist/**/*"

--- a/packages/is-strictly-equal/package.json
+++ b/packages/is-strictly-equal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assertions/is-strictly-equal",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/index.js",
   "files": [
     "dist/**/*"

--- a/packages/starts-with/package.json
+++ b/packages/starts-with/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assertions/starts-with",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/index.js",
   "files": [
     "dist/**/*"


### PR DESCRIPTION
The previous v1.0.1 publish didn't include the keywords for some reason: re-published with the keywords as v1.0.2 which has worked:

https://www.npmjs.com/search?q=keywords:actions-assert