### PR TITLE
chore: Bump version of `is-true`

### DIFF
--- a/is-true/package.json
+++ b/is-true/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assertions/is-true",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/index.js",
   "files": [
     "dist/**/*"


### PR DESCRIPTION
I made a mistake publishing this locally, need to bump the version to publish.