### PR TITLE
docs(equivalent-html): Add missing JSON conversion in example

### DIFF
--- a/equivalent-html/README.md
+++ b/equivalent-html/README.md
@@ -31,7 +31,7 @@ Part of the [assertions][@assertions] foundation collection.
   uses: pr-mpt/actions-assert@v3
   with:
     assertion: npm://@assertions/equivalent-html
-    actual: '${{ steps.request.outputs.response }}'
+    actual: '${{ fromJSON(steps.request.outputs.response) }}'
     expected: '${{ steps.fixture.outputs.content }}'
 ```
 


### PR DESCRIPTION
The response from the http request action is JSON encoded, so we need to decode to a normal string using `fromJSON`.